### PR TITLE
ci: Update deployment trigger

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -2,9 +2,6 @@
 name: build-and-deploy
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,6 +8,9 @@ on:
         type: environment
         required: true
         description: Environment for deployment
+  release:
+    types:
+      - published
   repository_dispatch:
     types:
       - content-updated


### PR DESCRIPTION
## Why?

- Cloudflare において Production or not の判定が branch しかない
- main ブランチへの merge を trigger して Production 以外のデータでデプロイすると Production が壊れる